### PR TITLE
Feature/fix multiprotocol k8s issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GH_TOKEN }}"

--- a/templates/jvb/service-tcp.yaml
+++ b/templates/jvb/service-tcp.yaml
@@ -1,8 +1,8 @@
-{{- if or (and (kindIs "invalid" .Values.jvb.service.enabled) (not .Values.jvb.useHostPort)) .Values.jvb.service.enabled }}
+{{- if and ((or (and (kindIs "invalid" .Values.jvb.service.enabled) (not .Values.jvb.useHostPort)) .Values.jvb.service.enabled)) .Values.jvb.websockets.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "jitsi-meet.jvb.fullname" . }}
+  name: {{ include "jitsi-meet.jvb.fullname" . }}-tcp
   annotations:
   {{- range $key, $value := .Values.jvb.service.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -15,17 +15,9 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   ports:
-    - port: {{ default 10000 .Values.jvb.UDPPort }}
-      {{- if or (eq .Values.jvb.service.type "NodePort") (eq .Values.jvb.service.type "LoadBalancer") }}
-      nodePort: {{ .Values.jvb.UDPPort }}
-      {{- end }}
-      protocol: UDP
-      name: rtp-udp
-    {{- if .Values.jvb.websockets.enabled }}
     - port: 9090
       protocol: TCP
       name: colibri-ws-tcp
-    {{- end }}
   {{- with .Values.jvb.service.externalIPs }}
   externalIPs:
   {{ toYaml . | indent 2 | trim }}

--- a/templates/jvb/service-udp.yaml
+++ b/templates/jvb/service-udp.yaml
@@ -1,0 +1,30 @@
+{{- if or (and (kindIs "invalid" .Values.jvb.service.enabled) (not .Values.jvb.useHostPort)) .Values.jvb.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.jvb.fullname" . }}-udp
+  annotations:
+  {{- range $key, $value := .Values.jvb.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.jvb.service.type }}
+  {{- with .Values.jvb.service.LoadbalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  ports:
+    - port: {{ default 10000 .Values.jvb.UDPPort }}
+      {{- if or (eq .Values.jvb.service.type "NodePort") (eq .Values.jvb.service.type "LoadBalancer") }}
+      nodePort: {{ .Values.jvb.UDPPort }}
+      {{- end }}
+      protocol: UDP
+      name: rtp-udp
+  {{- with .Values.jvb.service.externalIPs }}
+  externalIPs:
+  {{ toYaml . | indent 2 | trim }}
+  {{- end }}
+  selector:
+    {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Currently when we try to enable websockets in original jitsi-helm chart there is raised an error in K8S cluster that we are not allowed to create LoadBalancer service of multiprotocol type (udp, tcp) in kubernetes, so here I split it to 2 separate services.